### PR TITLE
Some changes to make the code compile with GO version 1.0.1. 

### DIFF
--- a/pty_linux.go
+++ b/pty_linux.go
@@ -14,7 +14,7 @@ const (
 
 
 // Opens a pty and its corresponding tty.
-func Open() (pty, tty *os.File, err os.Error) {
+func Open() (pty, tty *os.File, err error) {
 	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {
 		return nil, nil, err
@@ -38,7 +38,7 @@ func Open() (pty, tty *os.File, err os.Error) {
 }
 
 
-func ptsname(f *os.File) (string, os.Error) {
+func ptsname(f *os.File) (string, error) {
 	var n int
 	err := ioctl(f.Fd(), sys_TIOCGPTN, &n)
 	if err != nil {
@@ -48,21 +48,21 @@ func ptsname(f *os.File) (string, os.Error) {
 }
 
 
-func unlockpt(f *os.File) os.Error {
+func unlockpt(f *os.File) error {
 	var u int
 	return ioctl(f.Fd(), sys_TIOCSPTLCK, &u)
 }
 
 
-func ioctl(fd int, cmd uint, data *int) os.Error {
+func ioctl(fd uintptr, cmd uintptr, data *int) error {
 	_, _, e := syscall.Syscall(
 		syscall.SYS_IOCTL,
-		uintptr(fd),
-		uintptr(cmd),
+		fd,
+		cmd,
 		uintptr(unsafe.Pointer(data)),
 	)
 	if e != 0 {
-		return os.ENOTTY
+		return syscall.ENOTTY
 	}
 	return nil
 }

--- a/run.go
+++ b/run.go
@@ -1,7 +1,7 @@
 package pty
 
 import (
-	"exec"
+	"os/exec"
 	"os"
 )
 
@@ -12,21 +12,22 @@ import (
 // are the corresponding pty (Stderr is always nil).
 // Arguments name, argv, envv, and dir are passed
 // to os.StartProcess unchanged.
-func Run(name string, argv, envv []string, dir string) (c *exec.Cmd, err os.Error) {
+func Run(name string, argv, envv []string, dir string) (c *exec.Cmd, err error) {
 	c = new(exec.Cmd)
 	var fd [3]*os.File
-
-	c.Stdin, fd[0], err = Open()
+	var f *os.File
+	f, fd[0], err = Open()
 	if err != nil {
 		return nil, err
 	}
 	fd[1] = fd[0]
 	fd[2] = fd[0]
-	c.Stdout = c.Stdin
+	c.Stdout = f
+	c.Stdin = f
 	c.Process, err = os.StartProcess(name, argv, &os.ProcAttr{Env: envv, Dir: dir, Files: fd[:]})
 	fd[0].Close()
 	if err != nil {
-		c.Stdin.Close()
+		f.Close()
 		return nil, err
 	}
 	return c, nil


### PR DESCRIPTION
However, there would be also be some changes in functionality. This is due to changes in the type of cmd.Stdin and cmd.Stdout, and their inability to write as well read. The example given in readme.md doesn't work. I'm figuring out a way to make changes in the example so that it works.
