### PR TITLE
Add no O_NOCTTY, required for when there is no controlling terminal

### DIFF
--- a/pty_linux.go
+++ b/pty_linux.go
@@ -28,7 +28,7 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 
-	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
If this flag isn't there an the process doesn't have a controlling terminal it otherwise gets automatically assigned to the current process and fails to assign it to the child process.
