### PR TITLE
Add pty_unsupported.go file

### DIFF
--- a/pty_unsupported.go
+++ b/pty_unsupported.go
@@ -1,0 +1,32 @@
+// +build !linux,!darwin
+
+package pty
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	ErrUnsupported = errors.New("Unsupported")
+)
+
+func open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrUnsupported
+}
+
+func ptsname(f *os.File) (string, error) {
+	return "", ErrUnsupported
+}
+
+func grantpt(f *os.File) error {
+	return ErrUnsupported
+}
+
+func unlockpt(f *os.File) error {
+	return ErrUnsupported
+}
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	return ErrUnsupported
+}


### PR DESCRIPTION
In order to allow projects to import the package and still compile on other os/arch. we need a generic _unsupported file.

When adding freebsd support, we'll need to add it to the list here.
