### PR TITLE
Portable ioctl calls

### DIFF
--- a/ioctl.go
+++ b/ioctl.go
@@ -1,0 +1,11 @@
+package pty
+
+import "syscall"
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
+	if e != 0 {
+		return e
+	}
+	return nil
+}

--- a/ioctl_bsd.go
+++ b/ioctl_bsd.go
@@ -1,0 +1,39 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package pty
+
+// from <sys/ioccom.h>
+const (
+	_IOC_VOID    uintptr = 0x20000000
+	_IOC_OUT     uintptr = 0x40000000
+	_IOC_IN      uintptr = 0x80000000
+	_IOC_IN_OUT  uintptr = _IOC_OUT | _IOC_IN
+	_IOC_DIRMASK         = _IOC_VOID | _IOC_OUT | _IOC_IN
+
+	_IOC_PARAM_SHIFT = 13
+	_IOC_PARAM_MASK  = (1 << _IOC_PARAM_SHIFT) - 1
+)
+
+func _IOC_PARM_LEN(ioctl uintptr) uintptr {
+	return (ioctl >> 16) & _IOC_PARAM_MASK
+}
+
+func _IOC(inout uintptr, group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return inout | (param_len&_IOC_PARAM_MASK)<<16 | uintptr(group)<<8 | ioctl_num
+}
+
+func _IO(group byte, ioctl_num uintptr) uintptr {
+	return _IOC(_IOC_VOID, group, ioctl_num, 0)
+}
+
+func _IOR(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_OUT, group, ioctl_num, param_len)
+}
+
+func _IOW(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_IN, group, ioctl_num, param_len)
+}
+
+func _IOWR(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_IN_OUT, group, ioctl_num, param_len)
+}

--- a/ioctl_linux.go
+++ b/ioctl_linux.go
@@ -1,0 +1,42 @@
+package pty
+
+// from <asm-generic/ioctl.h>
+const (
+	_IOC_NRBITS   = 8
+	_IOC_TYPEBITS = 8
+
+	_IOC_SIZEBITS = 14
+	_IOC_DIRBITS  = 2
+
+	_IOC_NRSHIFT   = 0
+	_IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS
+	_IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS
+	_IOC_DIRSHIFT  = _IOC_SIZESHIFT + _IOC_SIZEBITS
+
+	_IOC_NONE  uint = 0
+	_IOC_WRITE uint = 1
+	_IOC_READ  uint = 2
+)
+
+func _IOC(dir uint, ioctl_type byte, nr byte, size uintptr) uintptr {
+	return (uintptr(dir)<<_IOC_DIRSHIFT |
+		uintptr(ioctl_type)<<_IOC_TYPESHIFT |
+		uintptr(nr)<<_IOC_NRSHIFT |
+		size<<_IOC_SIZESHIFT)
+}
+
+func _IO(ioctl_type byte, nr byte) uintptr {
+	return _IOC(_IOC_NONE, ioctl_type, nr, 0)
+}
+
+func _IOR(ioctl_type byte, nr byte, size uintptr) uintptr {
+	return _IOC(_IOC_READ, ioctl_type, nr, size)
+}
+
+func _IOW(ioctl_type byte, nr byte, size uintptr) uintptr {
+	return _IOC(_IOC_WRITE, ioctl_type, nr, size)
+}
+
+func _IOWR(ioctl_type byte, nr byte, size uintptr) uintptr {
+	return _IOC(_IOC_READ|_IOC_WRITE, ioctl_type, nr, size)
+}

--- a/mktypes.bash
+++ b/mktypes.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+GOOSARCH="${GOOS}_${GOARCH}"
+case "$GOOSARCH" in
+_* | *_ | _)
+	echo 'undefined $GOOS_$GOARCH:' "$GOOSARCH" 1>&2
+	exit 1
+	;;
+esac
+
+GODEFS="go tool cgo -godefs"
+
+$GODEFS types.go |gofmt > ztypes_$GOARCH.go
+
+case $GOOS in
+freebsd)
+	$GODEFS types_$GOOS.go |gofmt > ztypes_$GOOSARCH.go
+	;;
+esac

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -7,9 +7,6 @@ import (
 	"unsafe"
 )
 
-// see ioccom.h
-const sys_IOCPARM_MASK = 0x1fff
-
 func open() (pty, tty *os.File, err error) {
 	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {
@@ -39,9 +36,13 @@ func open() (pty, tty *os.File, err error) {
 }
 
 func ptsname(f *os.File) (string, error) {
-	var n [(syscall.TIOCPTYGNAME >> 16) & sys_IOCPARM_MASK]byte
+	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 
-	ioctl(f.Fd(), syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n)))
+	err := ioctl(f.Fd(), syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n[0])))
+	if err != nil {
+		return "", err
+	}
+
 	for i, c := range n {
 		if c == 0 {
 			return string(n[:i]), nil
@@ -51,19 +52,11 @@ func ptsname(f *os.File) (string, error) {
 }
 
 func grantpt(f *os.File) error {
-	var u int
+	var u _C_int
 	return ioctl(f.Fd(), syscall.TIOCPTYGRANT, uintptr(unsafe.Pointer(&u)))
 }
 
 func unlockpt(f *os.File) error {
-	var u int
+	var u _C_int
 	return ioctl(f.Fd(), syscall.TIOCPTYUNLK, uintptr(unsafe.Pointer(&u)))
-}
-
-func ioctl(fd, cmd, ptr uintptr) error {
-	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
-	if e != 0 {
-		return syscall.ENOTTY
-	}
-	return nil
 }

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -1,53 +1,78 @@
 package pty
 
 import (
+	"errors"
 	"os"
-	"strconv"
 	"syscall"
 	"unsafe"
 )
 
 const (
-	sys_TIOCGPTN   = 0x4004740F
-	sys_TIOCSPTLCK = 0x40045431
+	SPECNAMELEN = 63 /* max length of devicename <sys/param.h> */
 )
 
+func posix_openpt(oflag int) (fd int, err error) {
+	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
+	fd = int(r0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
 func open() (pty, tty *os.File, err error) {
-	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	fd, err := posix_openpt(syscall.O_RDWR)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	p := os.NewFile(uintptr(fd), "/dev/pts")
 	sname, err := ptsname(p)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
+	t, err := os.OpenFile("/dev/"+sname, os.O_RDWR, 0)
 	if err != nil {
 		return nil, nil, err
 	}
 	return p, t, nil
 }
 
+func isptmaster(fd uintptr) (bool, error) {
+	var result int
+	err := ioctl(fd, syscall.TIOCPTMASTER, uintptr(unsafe.Pointer(&result)))
+	return (result == 0), err
+}
+
+var (
+	emptyFiodgnameArg fiodgnameArg
+	ioctl_FIODGNAME   = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+)
+
 func ptsname(f *os.File) (string, error) {
-	var n int
-	err := ioctl(f.Fd(), sys_TIOCGPTN, &n)
+	master, err := isptmaster(f.Fd())
 	if err != nil {
 		return "", err
 	}
-	return "/dev/pts/" + strconv.Itoa(n), nil
-}
-
-func ioctl(fd uintptr, cmd uintptr, data *int) error {
-	_, _, e := syscall.Syscall(
-		syscall.SYS_IOCTL,
-		fd,
-		cmd,
-		uintptr(unsafe.Pointer(data)),
-	)
-	if e != 0 {
-		return syscall.ENOTTY
+	if !master {
+		return "", syscall.EINVAL
 	}
-	return nil
+
+	const n = SPECNAMELEN + 1
+	var (
+		buf = make([]byte, n)
+		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
+	)
+	err = ioctl(f.Fd(), ioctl_FIODGNAME, uintptr(unsafe.Pointer(&arg)))
+	if err != nil {
+		return "", err
+	}
+
+	for i, c := range buf {
+		if c == 0 {
+			return string(buf[:i]), nil
+		}
+	}
+	return "", errors.New("FIODGNAME string not NUL-terminated")
 }

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -7,9 +7,9 @@ import (
 	"unsafe"
 )
 
-const (
-	sys_TIOCGPTN   = 0x80045430
-	sys_TIOCSPTLCK = 0x40045431
+var (
+	ioctl_TIOCGPTN   = _IOR('T', 0x30, unsafe.Sizeof(_C_uint(0))) /* Get Pty Number (of pty-mux device) */
+	ioctl_TIOCSPTLCK = _IOW('T', 0x31, unsafe.Sizeof(_C_int(0)))  /* Lock/unlock Pty */
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -36,28 +36,15 @@ func open() (pty, tty *os.File, err error) {
 }
 
 func ptsname(f *os.File) (string, error) {
-	var n int
-	err := ioctl(f.Fd(), sys_TIOCGPTN, &n)
+	var n _C_uint
+	err := ioctl(f.Fd(), ioctl_TIOCGPTN, uintptr(unsafe.Pointer(&n)))
 	if err != nil {
 		return "", err
 	}
-	return "/dev/pts/" + strconv.Itoa(n), nil
+	return "/dev/pts/" + strconv.Itoa(int(n)), nil
 }
 
 func unlockpt(f *os.File) error {
-	var u int
-	return ioctl(f.Fd(), sys_TIOCSPTLCK, &u)
-}
-
-func ioctl(fd uintptr, cmd uintptr, data *int) error {
-	_, _, e := syscall.Syscall(
-		syscall.SYS_IOCTL,
-		fd,
-		cmd,
-		uintptr(unsafe.Pointer(data)),
-	)
-	if e != 0 {
-		return syscall.ENOTTY
-	}
-	return nil
+	var u _C_int
+	return ioctl(f.Fd(), ioctl_TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
 }

--- a/pty_unsupported.go
+++ b/pty_unsupported.go
@@ -9,19 +9,3 @@ import (
 func open() (pty, tty *os.File, err error) {
 	return nil, nil, ErrUnsupported
 }
-
-func ptsname(f *os.File) (string, error) {
-	return "", ErrUnsupported
-}
-
-func grantpt(f *os.File) error {
-	return ErrUnsupported
-}
-
-func unlockpt(f *os.File) error {
-	return ErrUnsupported
-}
-
-func ioctl(fd, cmd, ptr uintptr) error {
-	return ErrUnsupported
-}

--- a/types.go
+++ b/types.go
@@ -1,0 +1,10 @@
+// +build ignore
+
+package pty
+
+import "C"
+
+type (
+	_C_int  C.int
+	_C_uint C.uint
+)

--- a/types_freebsd.go
+++ b/types_freebsd.go
@@ -1,0 +1,8 @@
+// +build ignore
+
+package pty
+
+// #include <sys/filio.h>
+import "C"
+
+type fiodgnameArg C.struct_fiodgname_arg

--- a/ztypes_386.go
+++ b/ztypes_386.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/ztypes_amd64.go
+++ b/ztypes_amd64.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/ztypes_freebsd_386.go
+++ b/ztypes_freebsd_386.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+type fiodgnameArg struct {
+	Len int32
+	Buf *byte
+}

--- a/ztypes_freebsd_amd64.go
+++ b/ztypes_freebsd_amd64.go
@@ -1,0 +1,10 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+type fiodgnameArg struct {
+	Len       int32
+	Pad_cgo_0 [4]byte
+	Buf       *byte
+}


### PR DESCRIPTION
Add _IOC macros (<sys/ioccom.h>, <asm-generic/ioctl.h>) for linux and bsd's, unify ioctl() calls.
FreeBSD: use modern pts(4) interface instead of the old pty(4) one.
Use cgo -godefs generated ztypes_GOOS_GOARCH.go approach as in the syscall package to handle native C types.
