### PR TITLE
Add support for ARM

### DIFF
--- a/ztypes_arm.go
+++ b/ztypes_arm.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)


### PR DESCRIPTION
This was generated on a real Linux ARM box using the provided "mktypes.bash" script.  This makes `go build` on my ARM box succeed.
