### PR TITLE
Terminal make raw

### DIFF
--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -7,11 +7,6 @@ import (
 	"unsafe"
 )
 
-const (
-	ioctlReadTermios  = syscall.TIOCGETA
-	ioctlWriteTermios = syscall.TIOCSETA
-)
-
 func open() (pty, tty *os.File, err error) {
 	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -7,11 +7,6 @@ import (
 	"unsafe"
 )
 
-const (
-	ioctlReadTermios  = syscall.TIOCGETA
-	ioctlWriteTermios = syscall.TIOCSETA
-)
-
 func posix_openpt(oflag int) (fd int, err error) {
 	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
 	fd = int(r0)

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -7,11 +7,6 @@ import (
 	"unsafe"
 )
 
-const (
-	ioctlReadTermios  = 0x5401 // syscall.TCGETS
-	ioctlWriteTermios = 0x5402 // syscall.TCSETS
-)
-
 var (
 	ioctl_TIOCGPTN   = _IOR('T', 0x30, unsafe.Sizeof(_C_uint(0))) /* Get Pty Number (of pty-mux device) */
 	ioctl_TIOCSPTLCK = _IOW('T', 0x31, unsafe.Sizeof(_C_int(0)))  /* Lock/unlock Pty */


### PR DESCRIPTION
Allow better interactive mode. Code inspired by what is done in the `terminal` package from go `crypto/ssh` (see source code [here](https://code.google.com/p/go/source/browse/ssh/?repo=crypto#ssh%2Fterminal)). 

Basically:
- a function to make the tty raw, i.e disabling the echo when stdin is redirected to the tty among other things
- a function to restore the state of the tty
- a new `StartRaw` function that allows to use the improvement listed above without changing the existing API

I added an example of how to use it in the `README.md`.
