### PR TITLE
Add support for Power (ppc64, ppc64le) and System z (s390x)

### DIFF
--- a/ztypes_ppc64.go
+++ b/ztypes_ppc64.go
@@ -1,0 +1,11 @@
+// +build ppc64
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/ztypes_ppc64le.go
+++ b/ztypes_ppc64le.go
@@ -1,0 +1,11 @@
+// +build ppc64le
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/ztypes_s390x.go
+++ b/ztypes_s390x.go
@@ -1,0 +1,11 @@
+// +build s390x
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)


### PR DESCRIPTION
This PR add support for Power systems (ppc64, ppc64le) and System z (s390x).

We are working on porting Docker to Power and System z, and pty is an essential component for it.

Signed-off-by: Yohei Ueda yohei@jp.ibm.com
