### PR TITLE
Add support for the 32-bit PPC Linux platform

### DIFF
--- a/ztypes_ppc.go
+++ b/ztypes_ppc.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)


### PR DESCRIPTION
After this change i am able to compile docker for the e500v2 PowerPC CPU target.

Signed-off-by: Alex Samorukov samm@os2.kiev.ua
