### PR TITLE
support for Solaris

### DIFF
--- a/ioctl.go
+++ b/ioctl.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!solaris
 
 package pty
 

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -1,0 +1,24 @@
+package pty
+
+import (
+	"golang.org/x/sys/unix"
+	"unsafe"
+)
+
+const (
+	I_STR   = uintptr((int32('S')<<8 | 010))
+	ISPTM   = (int32('P') << 8) | 1
+	UNLKPT  = (int32('P') << 8) | 1
+	OWNERPT = (int32('P') << 8) | 5
+)
+
+type strioctl struct {
+	ic_cmd    int32
+	ic_timout int32
+	ic_len    int32
+	ic_dp     unsafe.Pointer
+}
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	return unix.IoctlSetInt(int(fd), uint(cmd), int(ptr))
+}

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -6,9 +6,15 @@ import (
 )
 
 const (
+	// see /usr/include/sys/stropts.h
+	I_PUSH  = uintptr((int32('S')<<8 | 002))
 	I_STR   = uintptr((int32('S')<<8 | 010))
+	I_FIND  = uintptr((int32('S')<<8 | 013))
+	// see /usr/include/sys/ptms.h
 	ISPTM   = (int32('P') << 8) | 1
-	UNLKPT  = (int32('P') << 8) | 1
+	UNLKPT  = (int32('P') << 8) | 2
+	PTSSTTY = (int32('P') << 8) | 3
+	ZONEPT  = (int32('P') << 8) | 4
 	OWNERPT = (int32('P') << 8) | 5
 )
 

--- a/pty_solaris.go
+++ b/pty_solaris.go
@@ -16,11 +16,12 @@ import (
 const NODEV = ^uint64(0)
 
 func open() (pty, tty *os.File, err error) {
-	pFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	masterfd, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|unix.O_NOCTTY, 0)
+	//masterfd, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC|unix.O_NOCTTY, 0)
 	if err != nil {
 		return nil, nil, err
 	}
-	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
+	p := os.NewFile(uintptr(masterfd), "/dev/ptmx")
 
 	sname, err := ptsname(p)
 	if err != nil {
@@ -37,10 +38,20 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 
-	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	slavefd, err := syscall.Open(sname, os.O_RDWR|unix.O_NOCTTY, 0)
 	if err != nil {
 		return nil, nil, err
 	}
+	t := os.NewFile(uintptr(slavefd), sname)
+
+	// pushing terminal driver STREAMS modules as per pts(7)
+	for _, mod := range([]string{"ptem", "ldterm", "ttcompat"}) {
+		err = streams_push(t, mod)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	
 	return p, t, nil
 }
 
@@ -67,7 +78,14 @@ func ptsname(f *os.File) (string, error) {
 	if dev == NODEV {
 		return "", errors.New("not a master pty")
 	}
-	return "/dev/pts/" + strconv.FormatInt(int64(dev), 10), nil
+	fn := "/dev/pts/" + strconv.FormatInt(int64(dev), 10)
+	// access(2) creates the slave device (if the pty exists)
+	// F_OK == 0 (unistd.h)
+	err := unix.Access(fn, 0)
+	if err != nil {
+		return "", err
+	}
+	return fn, nil
 }
 
 type pt_own struct {
@@ -98,4 +116,24 @@ func grantpt(f *os.File) error {
 func unlockpt(f *os.File) error {
 	istr := strioctl{UNLKPT, 0, 0, nil}
 	return ioctl(f.Fd(), I_STR, uintptr(unsafe.Pointer(&istr)))
+}
+
+// push STREAMS modules if not already done so
+func streams_push(f *os.File, mod string) error {
+	var err error
+	buf := []byte(mod)
+	// XXX I_FIND is not returning an error when the module
+	// is already pushed even though truss reports a return
+	// value of 1. A bug in the Go Solaris syscall interface?
+	// XXX without this we are at risk of the issue
+	// https://www.illumos.org/issues/9042
+	// but since we are not using libc or XPG4.2, we should not be
+	// double-pushing modules
+	
+	err = ioctl(f.Fd(), I_FIND, uintptr(unsafe.Pointer(&buf[0])))
+	if err != nil {
+		return nil
+	}
+	err = ioctl(f.Fd(), I_PUSH, uintptr(unsafe.Pointer(&buf[0])))
+	return err
 }

--- a/pty_solaris.go
+++ b/pty_solaris.go
@@ -1,0 +1,101 @@
+package pty
+
+/* based on:
+http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libc/port/gen/pt.c
+*/
+
+import (
+	"errors"
+	"golang.org/x/sys/unix"
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+const NODEV = ^uint64(0)
+
+func open() (pty, tty *os.File, err error) {
+	pFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = grantpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = unlockpt(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func minor(x uint64) uint64 {
+	return x & 0377
+}
+
+func ptsdev(fd uintptr) uint64 {
+	istr := strioctl{ISPTM, 0, 0, nil}
+	err := ioctl(fd, I_STR, uintptr(unsafe.Pointer(&istr)))
+	if err != nil {
+		return NODEV
+	}
+	var status unix.Stat_t
+	err = unix.Fstat(int(fd), &status)
+	if err != nil {
+		return NODEV
+	}
+	return uint64(minor(status.Rdev))
+}
+
+func ptsname(f *os.File) (string, error) {
+	dev := ptsdev(f.Fd())
+	if dev == NODEV {
+		return "", errors.New("not a master pty")
+	}
+	return "/dev/pts/" + strconv.FormatInt(int64(dev), 10), nil
+}
+
+type pt_own struct {
+	pto_ruid int32
+	pto_rgid int32
+}
+
+func grantpt(f *os.File) error {
+	if ptsdev(f.Fd()) == NODEV {
+		return errors.New("not a master pty")
+	}
+	var pto pt_own
+	pto.pto_ruid = int32(os.Getuid())
+	// XXX should first attempt to get gid of DEFAULT_TTY_GROUP="tty"
+	pto.pto_rgid = int32(os.Getgid())
+	var istr strioctl
+	istr.ic_cmd = OWNERPT
+	istr.ic_timout = 0
+	istr.ic_len = int32(unsafe.Sizeof(istr))
+	istr.ic_dp = unsafe.Pointer(&pto)
+	err := ioctl(f.Fd(), I_STR, uintptr(unsafe.Pointer(&istr)))
+	if err != nil {
+		return errors.New("access denied")
+	}
+	return nil
+}
+
+func unlockpt(f *os.File) error {
+	istr := strioctl{UNLKPT, 0, 0, nil}
+	return ioctl(f.Fd(), I_STR, uintptr(unsafe.Pointer(&istr)))
+}

--- a/pty_unsupported.go
+++ b/pty_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd,!dragonfly
+// +build !linux,!darwin,!freebsd,!dragonfly,!solaris
 
 package pty
 

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!solaris
 
 package pty
 

--- a/util_solaris.go
+++ b/util_solaris.go
@@ -1,3 +1,5 @@
+//
+
 package pty
 
 import (
@@ -6,8 +8,29 @@ import (
 )
 
 const (
-	TIOCGWINSZ = 21608
+	TIOCGWINSZ = 21608 // 'T' << 8 | 104
+	TIOCSWINSZ = 21607 // 'T' << 8 | 103
 )
+
+// Winsize describes the terminal size.
+type Winsize struct {
+	Rows uint16 // ws_row: Number of rows (in cells)
+	Cols uint16 // ws_col: Number of columns (in cells)
+	X    uint16 // ws_xpixel: Width in pixels
+	Y    uint16 // ws_ypixel: Height in pixels
+}
+
+// GetsizeFull returns the full terminal size description.
+func GetsizeFull(t *os.File) (size *Winsize, err error) {
+	var wsz *unix.Winsize
+	wsz, err = unix.IoctlGetWinsize(int(t.Fd()), TIOCGWINSZ)
+
+	if err != nil {
+		return nil, err
+	} else {
+		return &Winsize{wsz.Row, wsz.Col, wsz.Xpixel, wsz.Ypixel}, nil
+	}
+}
 
 // Get Windows Size
 func Getsize(t *os.File) (rows, cols int, err error) {
@@ -17,6 +40,12 @@ func Getsize(t *os.File) (rows, cols int, err error) {
 	if err != nil {
 		return 80, 25, err
 	} else {
-		return int(wsz.Row), int(wsz.Col), err
+		return int(wsz.Row), int(wsz.Col), nil
 	}
+}
+
+// Setsize resizes t to s.
+func Setsize(t *os.File, ws *Winsize) error {
+	wsz := unix.Winsize{ws.Rows, ws.Cols, ws.X, ws.Y}
+	return unix.IoctlSetWinsize(int(t.Fd()), TIOCSWINSZ, &wsz)
 }

--- a/util_solaris.go
+++ b/util_solaris.go
@@ -1,0 +1,22 @@
+package pty
+
+import (
+	"os"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	TIOCGWINSZ = 21608
+)
+
+// Get Windows Size
+func Getsize(t *os.File) (rows, cols int, err error) {
+	var wsz *unix.Winsize
+	wsz, err = unix.IoctlGetWinsize(int(t.Fd()), TIOCGWINSZ)
+
+	if err != nil {
+		return 80, 25, err
+	} else {
+		return int(wsz.Row), int(wsz.Col), err
+	}
+}


### PR DESCRIPTION
In the absence of a unit test suite, I verified this on SmartOS (Illumos kernel, an OpenSolaris derivative) using https://github.com/yudai/gotty as a test harness, but it should also work on Oracle Solaris.