### PR TITLE
Add no NOCTTY, required for when there is no controlling terminal

### DIFF
--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -33,7 +33,7 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 
-	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Needed in darwin when no controlling terminal is available, otherwise your application will immediately exit