### PR TITLE
Add O_NOCTTY for darwin when opening slave

### DIFF
--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -33,7 +33,7 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 
-	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Same as in #9, on darwin if there is no controlling terminal then opening a terminal will set that as the controlling terminal for the process which then causes a failure when setting it on the child.