### PR TITLE
README: replace deprecated crypto/ssh/terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Pty is a Go package for using unix pseudo-terminals.
 package main
 
 import (
-	"github.com/creack/pty"
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/creack/pty"
 )
 
 func main() {
@@ -51,7 +52,7 @@ import (
         "syscall"
 
         "github.com/creack/pty"
-        "golang.org/x/crypto/ssh/terminal"
+        "golang.org/x/term"
 )
 
 func test() error {
@@ -79,11 +80,11 @@ func test() error {
         ch <- syscall.SIGWINCH // Initial resize.
 
         // Set stdin in raw mode.
-        oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
+        oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
         if err != nil {
                 panic(err)
         }
-        defer func() { _ = terminal.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort.
+        defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort.
 
         // Copy stdin to the pty and the pty to stdout.
         go func() { _, _ = io.Copy(ptmx, os.Stdin) }()


### PR DESCRIPTION
The golang.org/x/crypto/ssh/terminal package was deprecated in favor of golang.org/x/term.

relates to https://github.com/golang/go/issues/31044 / https://github.com/golang/crypto/commit/4be66e5b658251a93e17d931a68d9c0ecba9f83a