### PR TITLE
Add pty.InheritSize for solaris support

### DIFF
--- a/util_solaris.go
+++ b/util_solaris.go
@@ -45,6 +45,21 @@ func Getsize(t *os.File) (rows, cols int, err error) {
 	}
 }
 
+// InheritSize applies the terminal size of pty to tty. This should be run
+// in a signal handler for syscall.SIGWINCH to automatically resize the tty when
+// the pty receives a window size change notification.
+func InheritSize(pty, tty *os.File) error {
+	size, err := GetsizeFull(pty)
+	if err != nil {
+		return err
+	}
+	err = Setsize(tty, size)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Setsize resizes t to s.
 func Setsize(t *os.File, ws *Winsize) error {
 	wsz := unix.Winsize{ws.Rows, ws.Cols, ws.X, ws.Y}


### PR DESCRIPTION
This at least allows eg https://github.com/cespare/reflex to build