### PR TITLE
Fix typo in openbsd build constraint

### DIFF
--- a/ztypes_openbsd_32bit_int.go
+++ b/ztypes_openbsd_32bit_int.go
@@ -1,4 +1,4 @@
-//go:build (386 || amd64 || arm || arm64 || mips64) && solaris
+//go:build (386 || amd64 || arm || arm64 || mips64) && openbsd
 //+build openbsd
 //+build 386 amd64 arm arm64 mips64
 


### PR DESCRIPTION
I noticed this when building termshark with Go 1.17.