### PR TITLE
Rename loongarchx to loong64.

### DIFF
--- a/ztypes_loong64.go
+++ b/ztypes_loong64.go
@@ -1,6 +1,5 @@
-//go:build (loongarch32 || loongarch64) && linux
-//+build linux
-//+build loongarch32 loongarch64
+//go:build loong64
+// +build loong64
 
 // Created by cgo -godefs - DO NOT EDIT
 // cgo -godefs types.go


### PR DESCRIPTION
loong64 GOARCH value reserved for LoongArch architecture:
	https://golang.org/doc/go1.17.

github issues:
	https://github.com/golang/go/issues/46229

LoongArch documents:
	https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html

Signed-off-by: guoqi.chen <chenguoqi@loongson.cn>