### PR TITLE
Use uint16 in winsize_unsupported.go

### DIFF
--- a/winsize_unsupported.go
+++ b/winsize_unsupported.go
@@ -9,7 +9,7 @@ import (
 
 // Winsize is a dummy struct to enable compilation on unsupported platforms.
 type Winsize struct {
-	Rows, Cols, X, Y uint
+	Rows, Cols, X, Y uint16
 }
 
 // Setsize resizes t to s.


### PR DESCRIPTION
Hi, Thank you so much for the wonderful project!

I changed the type to `uint16`  for struct compatibility with supported one.

https://github.com/creack/pty/blob/b135084511330383e4d0adc4504cf407cab59bb0/winsize_unix.go#L12-L18

Should we move the struct to `winsize.go` instead?