### PR TITLE
Provide correct pty/tty file paths on OpenBSD

### DIFF
--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -9,6 +9,17 @@ import (
 	"unsafe"
 )
 
+func cInt8ToString(in []int8) string {
+	var s []byte
+	for _, v := range in {
+		if v == 0 {
+			break
+		}
+		s = append(s, byte(v))
+	}
+	return string(s)
+}
+
 func open() (pty, tty *os.File, err error) {
 	/*
 	 * from ptm(4):
@@ -29,8 +40,8 @@ func open() (pty, tty *os.File, err error) {
 		return nil, nil, err
 	}
 
-	pty = os.NewFile(uintptr(ptm.Cfd), "/dev/ptm")
-	tty = os.NewFile(uintptr(ptm.Sfd), "/dev/ptm")
+	pty = os.NewFile(uintptr(ptm.Cfd), cInt8ToString(ptm.Cn[:]))
+	tty = os.NewFile(uintptr(ptm.Sfd), cInt8ToString(ptm.Sn[:]))
 
 	return pty, tty, nil
 }


### PR DESCRIPTION
While here, add test coverage for opening the TTY from the given filename.