### PR TITLE
Add non-blocking notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,4 +57,4 @@ jobs:
       # Run the tests again 100 times without verbose.
       - if: ${{ matrix.go_version != '1.6.x' }}
         name: Many Tests
-        run: go test -count=100 -timeout=10s
+        run: go test -count=100 -timeout=30s

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go get github.com/creack/pty
 
 ## Examples
 
-Note that those examples are for demonstration purpose only, to showcase how to use the library. They are not meant to be used in any kind of production environment.
+Note that those examples are for demonstration purpose only, to showcase how to use the library. They are not meant to be used in any kind of production environment. If you want to **set deadlines to work** and `Close()` **interrupting** `Read()` on the returned `*os.File`, you will need to call `syscall.SetNonblock` manually.
 
 ### Command
 

--- a/io_test.go
+++ b/io_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -28,9 +29,10 @@ var glTestFdLock sync.Mutex
 //
 //nolint:paralleltest // Potential in (*os.File).Fd().
 func TestReadDeadline(t *testing.T) {
-	t.Skip("Disabling while investigating race.")
-
 	ptmx, success := prepare(t)
+	if err := syscall.SetNonblock(int(ptmx.Fd()), true); err != nil {
+		t.Fatalf("Error: set non block: %s", err)
+	}
 
 	if err := ptmx.SetDeadline(time.Now().Add(timeout / 10)); err != nil {
 		if errors.Is(err, os.ErrNoDeadline) {
@@ -59,9 +61,10 @@ func TestReadDeadline(t *testing.T) {
 //
 //nolint:paralleltest // Potential in (*os.File).Fd().
 func TestReadClose(t *testing.T) {
-	t.Skip("Disabling while investigating race.")
-
 	ptmx, success := prepare(t)
+	if err := syscall.SetNonblock(int(ptmx.Fd()), true); err != nil {
+		t.Fatalf("Error: set non block: %s", err)
+	}
 
 	go func() {
 		time.Sleep(timeout / 10)


### PR DESCRIPTION
I have done some local testing, it turns out if the file is in non-blocking mode, `Getsize` will return zero sizes without any error. Setting the file in block mode will allow the result to be correct.

Instead, we could document that we can manually set a file to be non-blocking mode using `syscall.SetNonblock`, this will allow deadlines to work. I have set a larger timeout so the tests will succeed every time. Possibly this is due to how golang internal poller works, but that's up to golang to fix it.