### PR TITLE
ztypes_openbsd_32bit_int.go: remove arch list

### DIFF
--- a/ztypes_openbsd_32bit_int.go
+++ b/ztypes_openbsd_32bit_int.go
@@ -1,5 +1,4 @@
-//go:build (386 || amd64 || arm || arm64 || mips64) && openbsd
-// +build 386 amd64 arm arm64 mips64
+//go:build openbsd
 // +build openbsd
 
 package pty


### PR DESCRIPTION
struct ptmget is common across all OpenBSD architectures. The current version needlessly breaks compilation on ppc64 and riscv64.