### PR TITLE
Avoid calls to (*os.File).Fd() when calling ioctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go get github.com/creack/pty
 
 ## Examples
 
-Note that those examples are for demonstration purpose only, to showcase how to use the library. They are not meant to be used in any kind of production environment. If you want to **set deadlines to work** and `Close()` **interrupting** `Read()` on the returned `*os.File`, you will need to call `syscall.SetNonblock` manually.
+Note that those examples are for demonstration purpose only, to showcase how to use the library. They are not meant to be used in any kind of production environment.
 
 ### Command
 

--- a/io_test.go
+++ b/io_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -30,9 +29,6 @@ var glTestFdLock sync.Mutex
 //nolint:paralleltest // Potential in (*os.File).Fd().
 func TestReadDeadline(t *testing.T) {
 	ptmx, success := prepare(t)
-	if err := syscall.SetNonblock(int(ptmx.Fd()), true); err != nil {
-		t.Fatalf("Error: set non block: %s", err)
-	}
 
 	if err := ptmx.SetDeadline(time.Now().Add(timeout / 10)); err != nil {
 		if errors.Is(err, os.ErrNoDeadline) {
@@ -62,9 +58,6 @@ func TestReadDeadline(t *testing.T) {
 //nolint:paralleltest // Potential in (*os.File).Fd().
 func TestReadClose(t *testing.T) {
 	ptmx, success := prepare(t)
-	if err := syscall.SetNonblock(int(ptmx.Fd()), true); err != nil {
-		t.Fatalf("Error: set non block: %s", err)
-	}
 
 	go func() {
 		time.Sleep(timeout / 10)

--- a/ioctl.go
+++ b/ioctl.go
@@ -6,11 +6,6 @@ package pty
 import "os"
 
 func ioctl(f *os.File, cmd uintptr, ptr any) error {
-	return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io.
-}
-
-// NOTE: Unused. Keeping for reference.
-func ioctlNonblock(f *os.File, cmd uintptr, ptr any) error {
 	sc, e := f.SyscallConn()
 	if e != nil {
 		return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io (old behavior).

--- a/ioctl.go
+++ b/ioctl.go
@@ -5,21 +5,21 @@ package pty
 
 import "os"
 
-func ioctl(f *os.File, cmd, ptr uintptr) error {
-	return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io.
+func ioctl(f *os.File, cmd uintptr, ptr any) error {
+	return ioctlInner(f.Fd(), cmd, ptrToUintptr(ptr)) // Fall back to blocking io.
 }
 
 // NOTE: Unused. Keeping for reference.
-func ioctlNonblock(f *os.File, cmd, ptr uintptr) error {
+func ioctlNonblock(f *os.File, cmd uintptr, ptr any) error {
 	sc, e := f.SyscallConn()
 	if e != nil {
-		return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io (old behavior).
+		return ioctlInner(f.Fd(), cmd, ptrToUintptr(ptr)) // Fall back to blocking io (old behavior).
 	}
 
 	ch := make(chan error, 1)
 	defer close(ch)
 
-	e = sc.Control(func(fd uintptr) { ch <- ioctlInner(fd, cmd, ptr) })
+	e = sc.Control(func(fd uintptr) { ch <- ioctlInner(fd, cmd, ptrToUintptr(ptr)) })
 	if e != nil {
 		return e
 	}

--- a/ioctl.go
+++ b/ioctl.go
@@ -6,20 +6,20 @@ package pty
 import "os"
 
 func ioctl(f *os.File, cmd uintptr, ptr any) error {
-	return ioctlInner(f.Fd(), cmd, ptrToUintptr(ptr)) // Fall back to blocking io.
+	return ioctlInner(f.Fd(), cmd, ptrToUnsafePointer(ptr)) // Fall back to blocking io.
 }
 
 // NOTE: Unused. Keeping for reference.
 func ioctlNonblock(f *os.File, cmd uintptr, ptr any) error {
 	sc, e := f.SyscallConn()
 	if e != nil {
-		return ioctlInner(f.Fd(), cmd, ptrToUintptr(ptr)) // Fall back to blocking io (old behavior).
+		return ioctlInner(f.Fd(), cmd, ptrToUnsafePointer(ptr)) // Fall back to blocking io (old behavior).
 	}
 
 	ch := make(chan error, 1)
 	defer close(ch)
 
-	e = sc.Control(func(fd uintptr) { ch <- ioctlInner(fd, cmd, ptrToUintptr(ptr)) })
+	e = sc.Control(func(fd uintptr) { ch <- ioctlInner(fd, cmd, ptrToUnsafePointer(ptr)) })
 	if e != nil {
 		return e
 	}

--- a/ioctl.go
+++ b/ioctl.go
@@ -3,23 +3,26 @@
 
 package pty
 
-import "os"
+import (
+	"os"
+	"unsafe"
+)
 
-func ioctl(f *os.File, cmd uintptr, ptr any) error {
-	return ioctlInner(f.Fd(), cmd, ptrToUnsafePointer(ptr)) // Fall back to blocking io.
+func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
+	return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io.
 }
 
 // NOTE: Unused. Keeping for reference.
-func ioctlNonblock(f *os.File, cmd uintptr, ptr any) error {
+func ioctlNonblock(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
 	sc, e := f.SyscallConn()
 	if e != nil {
-		return ioctlInner(f.Fd(), cmd, ptrToUnsafePointer(ptr)) // Fall back to blocking io (old behavior).
+		return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io (old behavior).
 	}
 
 	ch := make(chan error, 1)
 	defer close(ch)
 
-	e = sc.Control(func(fd uintptr) { ch <- ioctlInner(fd, cmd, ptrToUnsafePointer(ptr)) })
+	e = sc.Control(func(fd uintptr) { ch <- ioctlInner(fd, cmd, ptr) })
 	if e != nil {
 		return e
 	}

--- a/ioctl.go
+++ b/ioctl.go
@@ -3,17 +3,14 @@
 
 package pty
 
-import (
-	"os"
-	"unsafe"
-)
+import "os"
 
-func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
+func ioctl(f *os.File, cmd uintptr, ptr any) error {
 	return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io.
 }
 
 // NOTE: Unused. Keeping for reference.
-func ioctlNonblock(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
+func ioctlNonblock(f *os.File, cmd uintptr, ptr any) error {
 	sc, e := f.SyscallConn()
 	if e != nil {
 		return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io (old behavior).

--- a/ioctl_inner.go
+++ b/ioctl_inner.go
@@ -3,7 +3,11 @@
 
 package pty
 
-import "syscall"
+import (
+	"reflect"
+	"syscall"
+	"unsafe"
+)
 
 // Local syscall const values.
 const (
@@ -12,7 +16,11 @@ const (
 )
 
 func ioctlInner(fd, cmd uintptr, ptr any) error {
-	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptrToUintptr(ptr))
+	var p unsafe.Pointer
+	if ptr != nil {
+		p = reflect.ValueOf(ptr).UnsafePointer()
+	}
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(p)) //nolint:gosec // ptr-to-uintptr at syscall site.
 	if e != 0 {
 		return e
 	}

--- a/ioctl_inner.go
+++ b/ioctl_inner.go
@@ -3,7 +3,10 @@
 
 package pty
 
-import "syscall"
+import (
+	"syscall"
+	"unsafe"
+)
 
 // Local syscall const values.
 const (
@@ -11,8 +14,8 @@ const (
 	TIOCSWINSZ = syscall.TIOCSWINSZ
 )
 
-func ioctlInner(fd, cmd, ptr uintptr) error {
-	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
+func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(ptr)) //nolint:gosec // ptr-to-uintptr at syscall site.
 	if e != 0 {
 		return e
 	}

--- a/ioctl_inner.go
+++ b/ioctl_inner.go
@@ -1,5 +1,5 @@
-//go:build !windows && !solaris && !aix
-// +build !windows,!solaris,!aix
+//go:build !windows && !solaris && !aix && go1.12
+// +build !windows,!solaris,!aix,go1.12
 
 package pty
 

--- a/ioctl_inner.go
+++ b/ioctl_inner.go
@@ -6,7 +6,6 @@ package pty
 import (
 	"reflect"
 	"syscall"
-	"unsafe"
 )
 
 // Local syscall const values.
@@ -16,11 +15,12 @@ const (
 )
 
 func ioctlInner(fd, cmd uintptr, ptr any) error {
-	var p unsafe.Pointer
-	if ptr != nil {
-		p = reflect.ValueOf(ptr).UnsafePointer()
+	var e syscall.Errno
+	if ptr == nil {
+		_, _, e = syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(0))
+	} else {
+		_, _, e = syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(reflect.ValueOf(ptr).UnsafePointer())) //nolint:gosec // ptr-to-uintptr at syscall site.
 	}
-	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(p)) //nolint:gosec // ptr-to-uintptr at syscall site.
 	if e != 0 {
 		return e
 	}

--- a/ioctl_inner.go
+++ b/ioctl_inner.go
@@ -3,10 +3,7 @@
 
 package pty
 
-import (
-	"syscall"
-	"unsafe"
-)
+import "syscall"
 
 // Local syscall const values.
 const (
@@ -14,8 +11,8 @@ const (
 	TIOCSWINSZ = syscall.TIOCSWINSZ
 )
 
-func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
-	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(ptr)) //nolint:gosec // ptr-to-uintptr at syscall site.
+func ioctlInner(fd, cmd uintptr, ptr any) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptrToUintptr(ptr))
 	if e != 0 {
 		return e
 	}

--- a/ioctl_legacy.go
+++ b/ioctl_legacy.go
@@ -6,5 +6,5 @@ package pty
 import "os"
 
 func ioctl(f *os.File, cmd uintptr, ptr any) error {
-	return ioctlInner(f.Fd(), cmd, ptrToUintptr(ptr)) // fall back to blocking io (old behavior)
+	return ioctlInner(f.Fd(), cmd, ptrToUnsafePointer(ptr)) // fall back to blocking io (old behavior)
 }

--- a/ioctl_legacy.go
+++ b/ioctl_legacy.go
@@ -3,8 +3,25 @@
 
 package pty
 
-import "os"
+import (
+	"os"
+	"reflect"
+	"syscall"
+)
 
-func ioctl(f *os.File, cmd uintptr, ptr any) error {
+func ioctl(f *os.File, cmd uintptr, ptr interface{}) error {
 	return ioctlInner(f.Fd(), cmd, ptr) // fall back to blocking io (old behavior)
+}
+
+func ioctlInner(fd, cmd uintptr, ptr interface{}) error {
+	var e syscall.Errno
+	if ptr == nil {
+		_, _, e = syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(0))
+	} else {
+		_, _, e = syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, reflect.ValueOf(ptr).UnsafeAddr()) //nolint:gosec // ptr-to-uintptr at syscall site.
+	}
+	if e != 0 {
+		return e
+	}
+	return nil
 }

--- a/ioctl_legacy.go
+++ b/ioctl_legacy.go
@@ -3,8 +3,11 @@
 
 package pty
 
-import "os"
+import (
+	"os"
+	"unsafe"
+)
 
-func ioctl(f *os.File, cmd uintptr, ptr any) error {
-	return ioctlInner(f.Fd(), cmd, ptrToUnsafePointer(ptr)) // fall back to blocking io (old behavior)
+func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
+	return ioctlInner(f.Fd(), cmd, ptr) // fall back to blocking io (old behavior)
 }

--- a/ioctl_legacy.go
+++ b/ioctl_legacy.go
@@ -3,11 +3,8 @@
 
 package pty
 
-import (
-	"os"
-	"unsafe"
-)
+import "os"
 
-func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
+func ioctl(f *os.File, cmd uintptr, ptr any) error {
 	return ioctlInner(f.Fd(), cmd, ptr) // fall back to blocking io (old behavior)
 }

--- a/ioctl_legacy.go
+++ b/ioctl_legacy.go
@@ -5,6 +5,6 @@ package pty
 
 import "os"
 
-func ioctl(f *os.File, cmd, ptr uintptr) error {
-	return ioctlInner(f.Fd(), cmd, ptr) // fall back to blocking io (old behavior)
+func ioctl(f *os.File, cmd uintptr, ptr any) error {
+	return ioctlInner(f.Fd(), cmd, ptrToUintptr(ptr)) // fall back to blocking io (old behavior)
 }

--- a/ioctl_ptr.go
+++ b/ioctl_ptr.go
@@ -2,17 +2,3 @@
 // +build !windows
 
 package pty
-
-import (
-	"reflect"
-	"unsafe"
-)
-
-// ptrToUnsafePointer converts a pointer value (passed as any) to an unsafe.Pointer for use in syscalls.
-// The final uintptr conversion must be deferred to the syscall.Syscall argument to satisfy the Go GC rules.
-func ptrToUnsafePointer(ptr any) unsafe.Pointer {
-	if ptr == nil {
-		return nil
-	}
-	return unsafe.Pointer(reflect.ValueOf(ptr).Pointer()) //nolint:gosec // Safe: reflect.Value keeps ptr alive; uintptr immediately converted back.
-}

--- a/ioctl_ptr.go
+++ b/ioctl_ptr.go
@@ -2,21 +2,3 @@
 // +build !windows
 
 package pty
-
-import "reflect"
-
-// ptrToUintptr returns the uintptr value of a pointer passed as any.
-// ptr must be a pointer type or nil. It is intended to be called directly
-// as an argument to syscall.Syscall so the conversion happens at the call site.
-func ptrToUintptr(ptr any) uintptr {
-	if ptr == nil {
-		return 0
-	}
-	v := reflect.ValueOf(ptr)
-	switch v.Kind() { //nolint:exhaustive
-	case reflect.Ptr, reflect.UnsafePointer:
-		return v.Pointer()
-	default:
-		panic("ptrToUintptr: ptr must be a pointer type")
-	}
-}

--- a/ioctl_ptr.go
+++ b/ioctl_ptr.go
@@ -2,3 +2,21 @@
 // +build !windows
 
 package pty
+
+import "reflect"
+
+// ptrToUintptr returns the uintptr value of a pointer passed as any.
+// ptr must be a pointer type or nil. It is intended to be called directly
+// as an argument to syscall.Syscall so the conversion happens at the call site.
+func ptrToUintptr(ptr any) uintptr {
+	if ptr == nil {
+		return 0
+	}
+	v := reflect.ValueOf(ptr)
+	switch v.Kind() { //nolint:exhaustive
+	case reflect.Ptr, reflect.UnsafePointer:
+		return v.Pointer()
+	default:
+		panic("ptrToUintptr: ptr must be a pointer type")
+	}
+}

--- a/ioctl_ptr.go
+++ b/ioctl_ptr.go
@@ -3,12 +3,16 @@
 
 package pty
 
-import "reflect"
+import (
+	"reflect"
+	"unsafe"
+)
 
-// ptrToUintptr converts a pointer value (passed as any) to its uintptr representation for use in syscalls.
-func ptrToUintptr(ptr any) uintptr {
+// ptrToUnsafePointer converts a pointer value (passed as any) to an unsafe.Pointer for use in syscalls.
+// The final uintptr conversion must be deferred to the syscall.Syscall argument to satisfy the Go GC rules.
+func ptrToUnsafePointer(ptr any) unsafe.Pointer {
 	if ptr == nil {
-		return 0
+		return nil
 	}
-	return reflect.ValueOf(ptr).Pointer()
+	return unsafe.Pointer(reflect.ValueOf(ptr).Pointer()) //nolint:gosec // Safe: reflect.Value keeps ptr alive; uintptr immediately converted back.
 }

--- a/ioctl_ptr.go
+++ b/ioctl_ptr.go
@@ -1,4 +1,0 @@
-//go:build !windows
-// +build !windows
-
-package pty

--- a/ioctl_ptr.go
+++ b/ioctl_ptr.go
@@ -1,0 +1,14 @@
+//go:build !windows
+// +build !windows
+
+package pty
+
+import "reflect"
+
+// ptrToUintptr converts a pointer value (passed as any) to its uintptr representation for use in syscalls.
+func ptrToUintptr(ptr any) uintptr {
+	if ptr == nil {
+		return 0
+	}
+	return reflect.ValueOf(ptr).Pointer()
+}

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -40,8 +40,8 @@ type strioctl struct {
 // Defined in asm_solaris_amd64.s.
 func sysvicall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
-func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
-	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(ptr), 0, 0, 0); errno != 0 { //nolint:gosec // ptr-to-uintptr at syscall site.
+func ioctlInner(fd, cmd uintptr, ptr any) error {
+	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, ptrToUintptr(ptr), 0, 0, 0); errno != 0 { //nolint:gosec // ptr-to-uintptr at syscall site.
 		return errno
 	}
 	return nil

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -42,11 +42,13 @@ type strioctl struct {
 func sysvicall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
 func ioctlInner(fd, cmd uintptr, ptr any) error {
-	var p unsafe.Pointer
-	if ptr != nil {
-		p = reflect.ValueOf(ptr).UnsafePointer()
+	var errno syscall.Errno
+	if ptr == nil {
+		_, _, errno = sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(0), 0, 0, 0)
+	} else {
+		_, _, errno = sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(reflect.ValueOf(ptr).UnsafePointer()), 0, 0, 0) //nolint:gosec // ptr-to-uintptr at syscall site.
 	}
-	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(p), 0, 0, 0); errno != 0 { //nolint:gosec // ptr-to-uintptr at syscall site.
+	if errno != 0 {
 		return errno
 	}
 	return nil

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -40,8 +40,8 @@ type strioctl struct {
 // Defined in asm_solaris_amd64.s.
 func sysvicall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
-func ioctlInner(fd, cmd, ptr uintptr) error {
-	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, ptr, 0, 0, 0); errno != 0 {
+func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
+	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(ptr), 0, 0, 0); errno != 0 { //nolint:gosec // ptr-to-uintptr at syscall site.
 		return errno
 	}
 	return nil

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -4,6 +4,7 @@
 package pty
 
 import (
+	"reflect"
 	"syscall"
 	"unsafe"
 )
@@ -41,7 +42,11 @@ type strioctl struct {
 func sysvicall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
 func ioctlInner(fd, cmd uintptr, ptr any) error {
-	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, ptrToUintptr(ptr), 0, 0, 0); errno != 0 { //nolint:gosec // ptr-to-uintptr at syscall site.
+	var p unsafe.Pointer
+	if ptr != nil {
+		p = reflect.ValueOf(ptr).UnsafePointer()
+	}
+	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(p), 0, 0, 0); errno != 0 { //nolint:gosec // ptr-to-uintptr at syscall site.
 		return errno
 	}
 	return nil

--- a/ioctl_unsupported.go
+++ b/ioctl_unsupported.go
@@ -3,11 +3,13 @@
 
 package pty
 
+import "unsafe"
+
 const (
 	TIOCGWINSZ = 0
 	TIOCSWINSZ = 0
 )
 
-func ioctlInner(fd, cmd, ptr uintptr) error {
+func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
 	return ErrUnsupported
 }

--- a/ioctl_unsupported.go
+++ b/ioctl_unsupported.go
@@ -3,13 +3,11 @@
 
 package pty
 
-import "unsafe"
-
 const (
 	TIOCGWINSZ = 0
 	TIOCSWINSZ = 0
 )
 
-func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
+func ioctlInner(fd, cmd uintptr, ptr any) error {
 	return ErrUnsupported
 }

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -46,7 +45,7 @@ func open() (pty, tty *os.File, err error) {
 func ptsname(f *os.File) (string, error) {
 	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 
-	err := ioctl(f, syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n[0])))
+	err := ioctl(f, syscall.TIOCPTYGNAME, &n[0])
 	if err != nil {
 		return "", err
 	}
@@ -60,9 +59,9 @@ func ptsname(f *os.File) (string, error) {
 }
 
 func grantpt(f *os.File) error {
-	return ioctl(f, syscall.TIOCPTYGRANT, 0)
+	return ioctl(f, syscall.TIOCPTYGRANT, nil)
 }
 
 func unlockpt(f *os.File) error {
-	return ioctl(f, syscall.TIOCPTYUNLK, 0)
+	return ioctl(f, syscall.TIOCPTYUNLK, nil)
 }

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"syscall"
+	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -45,7 +46,7 @@ func open() (pty, tty *os.File, err error) {
 func ptsname(f *os.File) (string, error) {
 	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 
-	err := ioctl(f, syscall.TIOCPTYGNAME, &n[0])
+	err := ioctl(f, syscall.TIOCPTYGNAME, unsafe.Pointer(&n[0]))
 	if err != nil {
 		return "", err
 	}

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -46,7 +45,7 @@ func open() (pty, tty *os.File, err error) {
 func ptsname(f *os.File) (string, error) {
 	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 
-	err := ioctl(f, syscall.TIOCPTYGNAME, unsafe.Pointer(&n[0]))
+	err := ioctl(f, syscall.TIOCPTYGNAME, &n[0])
 	if err != nil {
 		return "", err
 	}

--- a/pty_dragonfly.go
+++ b/pty_dragonfly.go
@@ -55,7 +55,7 @@ func unlockpt(f *os.File) error {
 }
 
 func isptmaster(f *os.File) (bool, error) {
-	err := ioctl(f, syscall.TIOCISPTMASTER, 0)
+	err := ioctl(f, syscall.TIOCISPTMASTER, nil)
 	return err == nil, err
 }
 
@@ -68,7 +68,7 @@ func ptsname(f *os.File) (string, error) {
 	name := make([]byte, _C_SPECNAMELEN)
 	fa := fiodgnameArg{Name: (*byte)(unsafe.Pointer(&name[0])), Len: _C_SPECNAMELEN, Pad_cgo_0: [4]byte{0, 0, 0, 0}}
 
-	err := ioctl(f, ioctl_FIODNAME, uintptr(unsafe.Pointer(&fa)))
+	err := ioctl(f, ioctl_FIODNAME, &fa)
 	if err != nil {
 		return "", err
 	}

--- a/pty_dragonfly.go
+++ b/pty_dragonfly.go
@@ -67,7 +67,7 @@ func ptsname(f *os.File) (string, error) {
 	name := make([]byte, _C_SPECNAMELEN)
 	fa := fiodgnameArg{Name: (*byte)(unsafe.Pointer(&name[0])), Len: _C_SPECNAMELEN, Pad_cgo_0: [4]byte{0, 0, 0, 0}}
 
-	err := ioctl(f, ioctl_FIODNAME, unsafe.Pointer(&fa))
+	err := ioctl(f, ioctl_FIODNAME, &fa)
 	if err != nil {
 		return "", err
 	}

--- a/pty_dragonfly.go
+++ b/pty_dragonfly.go
@@ -58,7 +58,6 @@ func isptmaster(f *os.File) (bool, error) {
 	err := ioctl(f, syscall.TIOCISPTMASTER, nil)
 	return err == nil, err
 }
-
 var (
 	emptyFiodgnameArg fiodgnameArg
 	ioctl_FIODNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
@@ -68,7 +67,7 @@ func ptsname(f *os.File) (string, error) {
 	name := make([]byte, _C_SPECNAMELEN)
 	fa := fiodgnameArg{Name: (*byte)(unsafe.Pointer(&name[0])), Len: _C_SPECNAMELEN, Pad_cgo_0: [4]byte{0, 0, 0, 0}}
 
-	err := ioctl(f, ioctl_FIODNAME, &fa)
+	err := ioctl(f, ioctl_FIODNAME, unsafe.Pointer(&fa))
 	if err != nil {
 		return "", err
 	}

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -48,7 +48,6 @@ func isptmaster(f *os.File) (bool, error) {
 	err := ioctl(f, syscall.TIOCPTMASTER, nil)
 	return err == nil, err
 }
-
 var (
 	emptyFiodgnameArg fiodgnameArg
 	ioctlFIODGNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
@@ -68,7 +67,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	if err := ioctl(f, ioctlFIODGNAME, &arg); err != nil {
+	if err := ioctl(f, ioctlFIODGNAME, unsafe.Pointer(&arg)); err != nil {
 		return "", err
 	}
 

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -67,7 +67,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	if err := ioctl(f, ioctlFIODGNAME, unsafe.Pointer(&arg)); err != nil {
+	if err := ioctl(f, ioctlFIODGNAME, &arg); err != nil {
 		return "", err
 	}
 

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -45,7 +45,7 @@ func open() (pty, tty *os.File, err error) {
 }
 
 func isptmaster(f *os.File) (bool, error) {
-	err := ioctl(f, syscall.TIOCPTMASTER, 0)
+	err := ioctl(f, syscall.TIOCPTMASTER, nil)
 	return err == nil, err
 }
 
@@ -68,7 +68,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	if err := ioctl(f, ioctlFIODGNAME, uintptr(unsafe.Pointer(&arg))); err != nil {
+	if err := ioctl(f, ioctlFIODGNAME, &arg); err != nil {
 		return "", err
 	}
 

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"syscall"
-	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -40,7 +39,7 @@ func open() (pty, tty *os.File, err error) {
 
 func ptsname(f *os.File) (string, error) {
 	var n _C_uint
-	err := ioctl(f, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))) //nolint:gosec // Expected unsafe pointer for Syscall call.
+	err := ioctl(f, syscall.TIOCGPTN, &n)
 	if err != nil {
 		return "", err
 	}
@@ -50,5 +49,5 @@ func ptsname(f *os.File) (string, error) {
 func unlockpt(f *os.File) error {
 	var u _C_int
 	// use TIOCSPTLCK with a pointer to zero to clear the lock.
-	return ioctl(f, syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))) //nolint:gosec // Expected unsafe pointer for Syscall call.
+	return ioctl(f, syscall.TIOCSPTLCK, &u)
 }

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"syscall"
+	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -39,7 +40,7 @@ func open() (pty, tty *os.File, err error) {
 
 func ptsname(f *os.File) (string, error) {
 	var n _C_uint
-	err := ioctl(f, syscall.TIOCGPTN, &n)
+	err := ioctl(f, syscall.TIOCGPTN, unsafe.Pointer(&n))
 	if err != nil {
 		return "", err
 	}
@@ -49,5 +50,5 @@ func ptsname(f *os.File) (string, error) {
 func unlockpt(f *os.File) error {
 	var u _C_int
 	// use TIOCSPTLCK with a pointer to zero to clear the lock.
-	return ioctl(f, syscall.TIOCSPTLCK, &u)
+	return ioctl(f, syscall.TIOCSPTLCK, unsafe.Pointer(&u))
 }

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strconv"
 	"syscall"
-	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -40,7 +39,7 @@ func open() (pty, tty *os.File, err error) {
 
 func ptsname(f *os.File) (string, error) {
 	var n _C_uint
-	err := ioctl(f, syscall.TIOCGPTN, unsafe.Pointer(&n))
+	err := ioctl(f, syscall.TIOCGPTN, &n)
 	if err != nil {
 		return "", err
 	}
@@ -50,5 +49,5 @@ func ptsname(f *os.File) (string, error) {
 func unlockpt(f *os.File) error {
 	var u _C_int
 	// use TIOCSPTLCK with a pointer to zero to clear the lock.
-	return ioctl(f, syscall.TIOCSPTLCK, unsafe.Pointer(&u))
+	return ioctl(f, syscall.TIOCSPTLCK, &u)
 }

--- a/pty_netbsd.go
+++ b/pty_netbsd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"syscall"
+	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -46,7 +47,7 @@ func ptsname(f *os.File) (string, error) {
 	 * ioctl(fd, TIOCPTSNAME, &pm) == -1 ? NULL : pm.sn;
 	 */
 	var ptm ptmget
-	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), &ptm); err != nil {
+	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), unsafe.Pointer(&ptm)); err != nil {
 		return "", err
 	}
 	name := make([]byte, len(ptm.Sn))

--- a/pty_netbsd.go
+++ b/pty_netbsd.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -47,7 +46,7 @@ func ptsname(f *os.File) (string, error) {
 	 * ioctl(fd, TIOCPTSNAME, &pm) == -1 ? NULL : pm.sn;
 	 */
 	var ptm ptmget
-	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), unsafe.Pointer(&ptm)); err != nil {
+	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), &ptm); err != nil {
 		return "", err
 	}
 	name := make([]byte, len(ptm.Sn))

--- a/pty_netbsd.go
+++ b/pty_netbsd.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 func open() (pty, tty *os.File, err error) {
@@ -47,7 +46,7 @@ func ptsname(f *os.File) (string, error) {
 	 * ioctl(fd, TIOCPTSNAME, &pm) == -1 ? NULL : pm.sn;
 	 */
 	var ptm ptmget
-	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), uintptr(unsafe.Pointer(&ptm))); err != nil {
+	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), &ptm); err != nil {
 		return "", err
 	}
 	name := make([]byte, len(ptm.Sn))
@@ -65,5 +64,5 @@ func grantpt(f *os.File) error {
 	 * from grantpt(3): Calling grantpt() is equivalent to:
 	 * ioctl(fd, TIOCGRANTPT, 0);
 	 */
-	return ioctl(f, uintptr(ioctl_TIOCGRANTPT), 0)
+	return ioctl(f, uintptr(ioctl_TIOCGRANTPT), nil)
 }

--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -6,7 +6,6 @@ package pty
 import (
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 func cInt8ToString(in []int8) string {
@@ -36,7 +35,7 @@ func open() (pty, tty *os.File, err error) {
 	defer p.Close()
 
 	var ptm ptmget
-	if err := ioctl(p, uintptr(ioctl_PTMGET), unsafe.Pointer(&ptm)); err != nil {
+	if err := ioctl(p, uintptr(ioctl_PTMGET), &ptm); err != nil {
 		return nil, nil, err
 	}
 

--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -6,6 +6,7 @@ package pty
 import (
 	"os"
 	"syscall"
+	"unsafe"
 )
 
 func cInt8ToString(in []int8) string {
@@ -35,7 +36,7 @@ func open() (pty, tty *os.File, err error) {
 	defer p.Close()
 
 	var ptm ptmget
-	if err := ioctl(p, uintptr(ioctl_PTMGET), &ptm); err != nil {
+	if err := ioctl(p, uintptr(ioctl_PTMGET), unsafe.Pointer(&ptm)); err != nil {
 		return nil, nil, err
 	}
 

--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -6,7 +6,6 @@ package pty
 import (
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 func cInt8ToString(in []int8) string {
@@ -36,7 +35,7 @@ func open() (pty, tty *os.File, err error) {
 	defer p.Close()
 
 	var ptm ptmget
-	if err := ioctl(p, uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
+	if err := ioctl(p, uintptr(ioctl_PTMGET), &ptm); err != nil {
 		return nil, nil, err
 	}
 

--- a/pty_solaris.go
+++ b/pty_solaris.go
@@ -84,7 +84,7 @@ func unlockpt(f *os.File) error {
 		icLen:     0,
 		icDP:      nil,
 	}
-	return ioctl(f, I_STR, &istr)
+	return ioctl(f, I_STR, unsafe.Pointer(&istr))
 }
 
 func minor(x uint64) uint64 { return x & 0377 }
@@ -97,7 +97,7 @@ func ptsdev(f *os.File) (uint64, error) {
 		icDP:      nil,
 	}
 
-	if err := ioctl(f, I_STR, &istr); err != nil {
+	if err := ioctl(f, I_STR, unsafe.Pointer(&istr)); err != nil {
 		return 0, err
 	}
 	var errors = make(chan error, 1)
@@ -146,7 +146,7 @@ func grantpt(f *os.File) error {
 		icLen:     int32(unsafe.Sizeof(strioctl{})),
 		icDP:      unsafe.Pointer(&pto),
 	}
-	if err := ioctl(f, I_STR, &istr); err != nil {
+	if err := ioctl(f, I_STR, unsafe.Pointer(&istr)); err != nil {
 		return errors.New("access denied")
 	}
 	return nil
@@ -164,8 +164,8 @@ func streamsPush(f *os.File, mod string) error {
 	// but since we are not using libc or XPG4.2, we should not be
 	// double-pushing modules
 
-	if err := ioctl(f, I_FIND, &buf[0]); err != nil {
+	if err := ioctl(f, I_FIND, unsafe.Pointer(&buf[0])); err != nil {
 		return nil
 	}
-	return ioctl(f, I_PUSH, &buf[0])
+	return ioctl(f, I_PUSH, unsafe.Pointer(&buf[0]))
 }

--- a/pty_solaris.go
+++ b/pty_solaris.go
@@ -84,7 +84,7 @@ func unlockpt(f *os.File) error {
 		icLen:     0,
 		icDP:      nil,
 	}
-	return ioctl(f, I_STR, uintptr(unsafe.Pointer(&istr)))
+	return ioctl(f, I_STR, &istr)
 }
 
 func minor(x uint64) uint64 { return x & 0377 }
@@ -97,7 +97,7 @@ func ptsdev(f *os.File) (uint64, error) {
 		icDP:      nil,
 	}
 
-	if err := ioctl(f, I_STR, uintptr(unsafe.Pointer(&istr))); err != nil {
+	if err := ioctl(f, I_STR, &istr); err != nil {
 		return 0, err
 	}
 	var errors = make(chan error, 1)
@@ -146,7 +146,7 @@ func grantpt(f *os.File) error {
 		icLen:     int32(unsafe.Sizeof(strioctl{})),
 		icDP:      unsafe.Pointer(&pto),
 	}
-	if err := ioctl(f, I_STR, uintptr(unsafe.Pointer(&istr))); err != nil {
+	if err := ioctl(f, I_STR, &istr); err != nil {
 		return errors.New("access denied")
 	}
 	return nil
@@ -164,8 +164,8 @@ func streamsPush(f *os.File, mod string) error {
 	// but since we are not using libc or XPG4.2, we should not be
 	// double-pushing modules
 
-	if err := ioctl(f, I_FIND, uintptr(unsafe.Pointer(&buf[0]))); err != nil {
+	if err := ioctl(f, I_FIND, &buf[0]); err != nil {
 		return nil
 	}
-	return ioctl(f, I_PUSH, uintptr(unsafe.Pointer(&buf[0])))
+	return ioctl(f, I_PUSH, &buf[0])
 }

--- a/pty_solaris.go
+++ b/pty_solaris.go
@@ -84,7 +84,7 @@ func unlockpt(f *os.File) error {
 		icLen:     0,
 		icDP:      nil,
 	}
-	return ioctl(f, I_STR, unsafe.Pointer(&istr))
+	return ioctl(f, I_STR, &istr)
 }
 
 func minor(x uint64) uint64 { return x & 0377 }
@@ -97,7 +97,7 @@ func ptsdev(f *os.File) (uint64, error) {
 		icDP:      nil,
 	}
 
-	if err := ioctl(f, I_STR, unsafe.Pointer(&istr)); err != nil {
+	if err := ioctl(f, I_STR, &istr); err != nil {
 		return 0, err
 	}
 	var errors = make(chan error, 1)
@@ -146,7 +146,7 @@ func grantpt(f *os.File) error {
 		icLen:     int32(unsafe.Sizeof(strioctl{})),
 		icDP:      unsafe.Pointer(&pto),
 	}
-	if err := ioctl(f, I_STR, unsafe.Pointer(&istr)); err != nil {
+	if err := ioctl(f, I_STR, &istr); err != nil {
 		return errors.New("access denied")
 	}
 	return nil
@@ -164,8 +164,8 @@ func streamsPush(f *os.File, mod string) error {
 	// but since we are not using libc or XPG4.2, we should not be
 	// double-pushing modules
 
-	if err := ioctl(f, I_FIND, unsafe.Pointer(&buf[0])); err != nil {
+	if err := ioctl(f, I_FIND, &buf[0]); err != nil {
 		return nil
 	}
-	return ioctl(f, I_PUSH, unsafe.Pointer(&buf[0]))
+	return ioctl(f, I_PUSH, &buf[0])
 }

--- a/winsize_unix.go
+++ b/winsize_unix.go
@@ -6,6 +6,7 @@ package pty
 import (
 	"os"
 	"syscall"
+	"unsafe"
 )
 
 // Winsize describes the terminal size.
@@ -18,14 +19,14 @@ type Winsize struct {
 
 // Setsize resizes t to s.
 func Setsize(t *os.File, ws *Winsize) error {
-	return ioctl(t, syscall.TIOCSWINSZ, ws)
+	return ioctl(t, syscall.TIOCSWINSZ, unsafe.Pointer(ws))
 }
 
 // GetsizeFull returns the full terminal size description.
 func GetsizeFull(t *os.File) (size *Winsize, err error) {
 	var ws Winsize
 
-	if err := ioctl(t, syscall.TIOCGWINSZ, &ws); err != nil {
+	if err := ioctl(t, syscall.TIOCGWINSZ, unsafe.Pointer(&ws)); err != nil {
 		return nil, err
 	}
 	return &ws, nil

--- a/winsize_unix.go
+++ b/winsize_unix.go
@@ -6,7 +6,6 @@ package pty
 import (
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 // Winsize describes the terminal size.
@@ -19,14 +18,14 @@ type Winsize struct {
 
 // Setsize resizes t to s.
 func Setsize(t *os.File, ws *Winsize) error {
-	return ioctl(t, syscall.TIOCSWINSZ, unsafe.Pointer(ws))
+	return ioctl(t, syscall.TIOCSWINSZ, ws)
 }
 
 // GetsizeFull returns the full terminal size description.
 func GetsizeFull(t *os.File) (size *Winsize, err error) {
 	var ws Winsize
 
-	if err := ioctl(t, syscall.TIOCGWINSZ, unsafe.Pointer(&ws)); err != nil {
+	if err := ioctl(t, syscall.TIOCGWINSZ, &ws); err != nil {
 		return nil, err
 	}
 	return &ws, nil

--- a/winsize_unix.go
+++ b/winsize_unix.go
@@ -6,7 +6,6 @@ package pty
 import (
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 // Winsize describes the terminal size.
@@ -19,16 +18,14 @@ type Winsize struct {
 
 // Setsize resizes t to s.
 func Setsize(t *os.File, ws *Winsize) error {
-	//nolint:gosec // Expected unsafe pointer for Syscall call.
-	return ioctl(t, syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(ws)))
+	return ioctl(t, syscall.TIOCSWINSZ, ws)
 }
 
 // GetsizeFull returns the full terminal size description.
 func GetsizeFull(t *os.File) (size *Winsize, err error) {
 	var ws Winsize
 
-	//nolint:gosec // Expected unsafe pointer for Syscall call.
-	if err := ioctl(t, syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws))); err != nil {
+	if err := ioctl(t, syscall.TIOCGWINSZ, &ws); err != nil {
 		return nil, err
 	}
 	return &ws, nil


### PR DESCRIPTION
In #167 `(*os.File).SyscallConn()` is used whenever possible, but it caused some operations to fail sometimes and had to be reverted.

The problem is not race condition, but incorrect usage of `uintptr`. In go, any pointer value should only be converted to uintptr when passed as arguments to `syscall.Syscall`.

According to [test results](https://github.com/creack/pty/discussions/211), even the blocking version may rarely have this kind of problem.

Copilot was used to refactor the function signature and some manual editing to make sure it works.