### PR TITLE
Avoid calls to (*os.File).Fd() when calling ioctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go get github.com/creack/pty
 
 ## Examples
 
-Note that those examples are for demonstration purpose only, to showcase how to use the library. They are not meant to be used in any kind of production environment. If you want to **set deadlines to work** and `Close()` **interrupting** `Read()` on the returned `*os.File`, you will need to call `syscall.SetNonblock` manually.
+Note that those examples are for demonstration purpose only, to showcase how to use the library. They are not meant to be used in any kind of production environment.
 
 ### Command
 

--- a/io_test.go
+++ b/io_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"runtime"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -30,9 +29,6 @@ var glTestFdLock sync.Mutex
 //nolint:paralleltest // Potential in (*os.File).Fd().
 func TestReadDeadline(t *testing.T) {
 	ptmx, success := prepare(t)
-	if err := syscall.SetNonblock(int(ptmx.Fd()), true); err != nil {
-		t.Fatalf("Error: set non block: %s", err)
-	}
 
 	if err := ptmx.SetDeadline(time.Now().Add(timeout / 10)); err != nil {
 		if errors.Is(err, os.ErrNoDeadline) {
@@ -62,9 +58,6 @@ func TestReadDeadline(t *testing.T) {
 //nolint:paralleltest // Potential in (*os.File).Fd().
 func TestReadClose(t *testing.T) {
 	ptmx, success := prepare(t)
-	if err := syscall.SetNonblock(int(ptmx.Fd()), true); err != nil {
-		t.Fatalf("Error: set non block: %s", err)
-	}
 
 	go func() {
 		time.Sleep(timeout / 10)

--- a/ioctl.go
+++ b/ioctl.go
@@ -3,15 +3,17 @@
 
 package pty
 
-import "os"
+import (
+	"os"
+	"unsafe"
+)
 
-func ioctl(f *os.File, cmd, ptr uintptr) error {
+func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
 	return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io.
 }
 
 // NOTE: Unused. Keeping for reference.
-func ioctlNonblock(f *os.File, cmd, ptr uintptr) error {
-	sc, e := f.SyscallConn()
+func ioctlNonblock(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {	sc, e := f.SyscallConn()
 	if e != nil {
 		return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io (old behavior).
 	}

--- a/ioctl.go
+++ b/ioctl.go
@@ -9,11 +9,7 @@ import (
 )
 
 func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
-	return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io.
-}
-
-// NOTE: Unused. Keeping for reference.
-func ioctlNonblock(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {	sc, e := f.SyscallConn()
+	sc, e := f.SyscallConn()
 	if e != nil {
 		return ioctlInner(f.Fd(), cmd, ptr) // Fall back to blocking io (old behavior).
 	}

--- a/ioctl_inner.go
+++ b/ioctl_inner.go
@@ -3,7 +3,10 @@
 
 package pty
 
-import "syscall"
+import (
+	"syscall"
+	"unsafe"
+)
 
 // Local syscall const values.
 const (
@@ -11,8 +14,8 @@ const (
 	TIOCSWINSZ = syscall.TIOCSWINSZ
 )
 
-func ioctlInner(fd, cmd, ptr uintptr) error {
-	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
+func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(ptr))
 	if e != 0 {
 		return e
 	}

--- a/ioctl_legacy.go
+++ b/ioctl_legacy.go
@@ -3,8 +3,11 @@
 
 package pty
 
-import "os"
+import (
+	"os"
+	"unsafe"
+)
 
-func ioctl(f *os.File, cmd, ptr uintptr) error {
+func ioctl(f *os.File, cmd uintptr, ptr unsafe.Pointer) error {
 	return ioctlInner(f.Fd(), cmd, ptr) // fall back to blocking io (old behavior)
 }

--- a/ioctl_solaris.go
+++ b/ioctl_solaris.go
@@ -40,8 +40,8 @@ type strioctl struct {
 // Defined in asm_solaris_amd64.s.
 func sysvicall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
 
-func ioctlInner(fd, cmd, ptr uintptr) error {
-	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, ptr, 0, 0, 0); errno != 0 {
+func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
+	if _, _, errno := sysvicall6(uintptr(unsafe.Pointer(&procioctl)), 3, fd, cmd, uintptr(ptr), 0, 0, 0); errno != 0 {
 		return errno
 	}
 	return nil

--- a/ioctl_unsupported.go
+++ b/ioctl_unsupported.go
@@ -3,11 +3,13 @@
 
 package pty
 
+import "unsafe"
+
 const (
 	TIOCGWINSZ = 0
 	TIOCSWINSZ = 0
 )
 
-func ioctlInner(fd, cmd, ptr uintptr) error {
+func ioctlInner(fd, cmd uintptr, ptr unsafe.Pointer) error {
 	return ErrUnsupported
 }

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -46,7 +46,7 @@ func open() (pty, tty *os.File, err error) {
 func ptsname(f *os.File) (string, error) {
 	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 
-	err := ioctl(f, syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n[0])))
+	err := ioctl(f, syscall.TIOCPTYGNAME, unsafe.Pointer(&n[0]))
 	if err != nil {
 		return "", err
 	}
@@ -60,9 +60,9 @@ func ptsname(f *os.File) (string, error) {
 }
 
 func grantpt(f *os.File) error {
-	return ioctl(f, syscall.TIOCPTYGRANT, 0)
+	return ioctl(f, syscall.TIOCPTYGRANT, unsafe.Pointer(0))
 }
 
 func unlockpt(f *os.File) error {
-	return ioctl(f, syscall.TIOCPTYUNLK, 0)
+	return ioctl(f, syscall.TIOCPTYUNLK, unsafe.Pointer(0))
 }

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -60,9 +60,9 @@ func ptsname(f *os.File) (string, error) {
 }
 
 func grantpt(f *os.File) error {
-	return ioctl(f, syscall.TIOCPTYGRANT, unsafe.Pointer(0))
+	return ioctl(f, syscall.TIOCPTYGRANT, unsafe.Pointer(nil))
 }
 
 func unlockpt(f *os.File) error {
-	return ioctl(f, syscall.TIOCPTYUNLK, unsafe.Pointer(0))
+	return ioctl(f, syscall.TIOCPTYUNLK, unsafe.Pointer(nil))
 }

--- a/pty_dragonfly.go
+++ b/pty_dragonfly.go
@@ -55,7 +55,7 @@ func unlockpt(f *os.File) error {
 }
 
 func isptmaster(f *os.File) (bool, error) {
-	err := ioctl(f, syscall.TIOCISPTMASTER, 0)
+	err := ioctl(f, syscall.TIOCISPTMASTER, unsafe.Pointer(0))
 	return err == nil, err
 }
 
@@ -68,7 +68,7 @@ func ptsname(f *os.File) (string, error) {
 	name := make([]byte, _C_SPECNAMELEN)
 	fa := fiodgnameArg{Name: (*byte)(unsafe.Pointer(&name[0])), Len: _C_SPECNAMELEN, Pad_cgo_0: [4]byte{0, 0, 0, 0}}
 
-	err := ioctl(f, ioctl_FIODNAME, uintptr(unsafe.Pointer(&fa)))
+	err := ioctl(f, ioctl_FIODNAME, unsafe.Pointer(&fa))
 	if err != nil {
 		return "", err
 	}

--- a/pty_dragonfly.go
+++ b/pty_dragonfly.go
@@ -55,7 +55,7 @@ func unlockpt(f *os.File) error {
 }
 
 func isptmaster(f *os.File) (bool, error) {
-	err := ioctl(f, syscall.TIOCISPTMASTER, unsafe.Pointer(0))
+	err := ioctl(f, syscall.TIOCISPTMASTER, unsafe.Pointer(nil))
 	return err == nil, err
 }
 

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -45,7 +45,7 @@ func open() (pty, tty *os.File, err error) {
 }
 
 func isptmaster(f *os.File) (bool, error) {
-	err := ioctl(f, syscall.TIOCPTMASTER, unsafe.Pointer(0))
+	err := ioctl(f, syscall.TIOCPTMASTER, unsafe.Pointer(nil))
 	return err == nil, err
 }
 

--- a/pty_freebsd.go
+++ b/pty_freebsd.go
@@ -45,7 +45,7 @@ func open() (pty, tty *os.File, err error) {
 }
 
 func isptmaster(f *os.File) (bool, error) {
-	err := ioctl(f, syscall.TIOCPTMASTER, 0)
+	err := ioctl(f, syscall.TIOCPTMASTER, unsafe.Pointer(0))
 	return err == nil, err
 }
 
@@ -68,7 +68,7 @@ func ptsname(f *os.File) (string, error) {
 		buf = make([]byte, n)
 		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
 	)
-	if err := ioctl(f, ioctlFIODGNAME, uintptr(unsafe.Pointer(&arg))); err != nil {
+	if err := ioctl(f, ioctlFIODGNAME, unsafe.Pointer(&arg)); err != nil {
 		return "", err
 	}
 

--- a/pty_linux.go
+++ b/pty_linux.go
@@ -40,7 +40,7 @@ func open() (pty, tty *os.File, err error) {
 
 func ptsname(f *os.File) (string, error) {
 	var n _C_uint
-	err := ioctl(f, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))) //nolint:gosec // Expected unsafe pointer for Syscall call.
+	err := ioctl(f, syscall.TIOCGPTN, unsafe.Pointer(&n)) //nolint:gosec // Expected unsafe pointer for Syscall call.
 	if err != nil {
 		return "", err
 	}
@@ -50,5 +50,5 @@ func ptsname(f *os.File) (string, error) {
 func unlockpt(f *os.File) error {
 	var u _C_int
 	// use TIOCSPTLCK with a pointer to zero to clear the lock.
-	return ioctl(f, syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u))) //nolint:gosec // Expected unsafe pointer for Syscall call.
+	return ioctl(f, syscall.TIOCSPTLCK, unsafe.Pointer(&u)) //nolint:gosec // Expected unsafe pointer for Syscall call.
 }

--- a/pty_netbsd.go
+++ b/pty_netbsd.go
@@ -47,7 +47,7 @@ func ptsname(f *os.File) (string, error) {
 	 * ioctl(fd, TIOCPTSNAME, &pm) == -1 ? NULL : pm.sn;
 	 */
 	var ptm ptmget
-	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), uintptr(unsafe.Pointer(&ptm))); err != nil {
+	if err := ioctl(f, uintptr(ioctl_TIOCPTSNAME), unsafe.Pointer(&ptm)); err != nil {
 		return "", err
 	}
 	name := make([]byte, len(ptm.Sn))
@@ -65,5 +65,5 @@ func grantpt(f *os.File) error {
 	 * from grantpt(3): Calling grantpt() is equivalent to:
 	 * ioctl(fd, TIOCGRANTPT, 0);
 	 */
-	return ioctl(f, uintptr(ioctl_TIOCGRANTPT), 0)
+	return ioctl(f, uintptr(ioctl_TIOCGRANTPT), unsafe.Pointer(0))
 }

--- a/pty_netbsd.go
+++ b/pty_netbsd.go
@@ -65,5 +65,5 @@ func grantpt(f *os.File) error {
 	 * from grantpt(3): Calling grantpt() is equivalent to:
 	 * ioctl(fd, TIOCGRANTPT, 0);
 	 */
-	return ioctl(f, uintptr(ioctl_TIOCGRANTPT), unsafe.Pointer(0))
+	return ioctl(f, uintptr(ioctl_TIOCGRANTPT), unsafe.Pointer(nil))
 }

--- a/pty_openbsd.go
+++ b/pty_openbsd.go
@@ -36,7 +36,7 @@ func open() (pty, tty *os.File, err error) {
 	defer p.Close()
 
 	var ptm ptmget
-	if err := ioctl(p, uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
+	if err := ioctl(p, uintptr(ioctl_PTMGET), unsafe.Pointer(&ptm)); err != nil {
 		return nil, nil, err
 	}
 

--- a/pty_solaris.go
+++ b/pty_solaris.go
@@ -84,7 +84,7 @@ func unlockpt(f *os.File) error {
 		icLen:     0,
 		icDP:      nil,
 	}
-	return ioctl(f, I_STR, uintptr(unsafe.Pointer(&istr)))
+	return ioctl(f, I_STR, unsafe.Pointer(&istr))
 }
 
 func minor(x uint64) uint64 { return x & 0377 }
@@ -97,7 +97,7 @@ func ptsdev(f *os.File) (uint64, error) {
 		icDP:      nil,
 	}
 
-	if err := ioctl(f, I_STR, uintptr(unsafe.Pointer(&istr))); err != nil {
+	if err := ioctl(f, I_STR, unsafe.Pointer(&istr)); err != nil {
 		return 0, err
 	}
 	var errors = make(chan error, 1)
@@ -146,7 +146,7 @@ func grantpt(f *os.File) error {
 		icLen:     int32(unsafe.Sizeof(strioctl{})),
 		icDP:      unsafe.Pointer(&pto),
 	}
-	if err := ioctl(f, I_STR, uintptr(unsafe.Pointer(&istr))); err != nil {
+	if err := ioctl(f, I_STR, unsafe.Pointer(&istr)); err != nil {
 		return errors.New("access denied")
 	}
 	return nil
@@ -164,8 +164,8 @@ func streamsPush(f *os.File, mod string) error {
 	// but since we are not using libc or XPG4.2, we should not be
 	// double-pushing modules
 
-	if err := ioctl(f, I_FIND, uintptr(unsafe.Pointer(&buf[0]))); err != nil {
+	if err := ioctl(f, I_FIND, unsafe.Pointer(&buf[0])); err != nil {
 		return nil
 	}
-	return ioctl(f, I_PUSH, uintptr(unsafe.Pointer(&buf[0])))
+	return ioctl(f, I_PUSH, unsafe.Pointer(&buf[0]))
 }

--- a/winsize_unix.go
+++ b/winsize_unix.go
@@ -20,7 +20,7 @@ type Winsize struct {
 // Setsize resizes t to s.
 func Setsize(t *os.File, ws *Winsize) error {
 	//nolint:gosec // Expected unsafe pointer for Syscall call.
-	return ioctl(t, syscall.TIOCSWINSZ, uintptr(unsafe.Pointer(ws)))
+	return ioctl(t, syscall.TIOCSWINSZ, unsafe.Pointer(ws))
 }
 
 // GetsizeFull returns the full terminal size description.
@@ -28,7 +28,7 @@ func GetsizeFull(t *os.File) (size *Winsize, err error) {
 	var ws Winsize
 
 	//nolint:gosec // Expected unsafe pointer for Syscall call.
-	if err := ioctl(t, syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws))); err != nil {
+	if err := ioctl(t, syscall.TIOCGWINSZ, unsafe.Pointer(&ws)); err != nil {
 		return nil, err
 	}
 	return &ws, nil


### PR DESCRIPTION
Like #214 , but use `unsafe.Pointer` as a parameter to avoid the use of `reflect`.